### PR TITLE
Update the baudrate in bittle_driver.py

### DIFF
--- a/scripts/bittle_driver.py
+++ b/scripts/bittle_driver.py
@@ -18,7 +18,7 @@ class Driver:
         rospy.Subscriber("/cmd_vel", Twist, self.callback)
         self.ser = serial.Serial(
         port=port,
-        baudrate=57600,
+        baudrate=115200, # the newest OpenCat code uses 115200
         parity=serial.PARITY_NONE,
         stopbits=serial.STOPBITS_ONE,
         bytesize=serial.EIGHTBITS,


### PR DESCRIPTION
We have updated the baudrate to 115200 in the newest OpenCat firmware. 